### PR TITLE
Add deployment link button to header alongside GitHub link

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,7 @@
 import { BrowserRouter as Router, Routes, Route, Navigate, Link } from 'react-router-dom';
 import { useState, useEffect } from 'react';
 import ChatPage from './pages/ChatPage';
-import { GITHUB_REPO_URL } from './config/constants';
+import { GITHUB_REPO_URL, DEPLOYMENT_URL } from './config/constants';
 
 function App() {
   const [windowDimensions, setWindowDimensions] = useState({
@@ -27,26 +27,48 @@ function App() {
       <div className="app">
         <header style={{ height: headerHeight, display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '0 20px', backgroundColor: '#282c34', color: 'white', fontFamily: 'Comfortaa, sans-serif' }}>
           <h1><Link to="/nwb-assistant/" style={{ textDecoration: 'none', color: 'inherit' }}>NWB Assistant</Link></h1>
-          <a 
-            href={GITHUB_REPO_URL} 
-            target="_blank" 
-            rel="noopener noreferrer"
-            style={{ 
-              color: 'white', 
-              textDecoration: 'none',
-              display: 'flex',
-              alignItems: 'center',
-              opacity: 0.8,
-              transition: 'opacity 0.2s'
-            }}
-            onMouseEnter={(e) => e.currentTarget.style.opacity = '1'}
-            onMouseLeave={(e) => e.currentTarget.style.opacity = '0.8'}
-            title="View on GitHub"
-          >
-            <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor">
-              <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/>
-            </svg>
-          </a>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
+            <a 
+              href={DEPLOYMENT_URL} 
+              target="_blank" 
+              rel="noopener noreferrer"
+              style={{ 
+                color: 'white', 
+                textDecoration: 'none',
+                display: 'flex',
+                alignItems: 'center',
+                opacity: 0.8,
+                transition: 'opacity 0.2s'
+              }}
+              onMouseEnter={(e) => e.currentTarget.style.opacity = '1'}
+              onMouseLeave={(e) => e.currentTarget.style.opacity = '0.8'}
+              title="Open in new window"
+            >
+              <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
+                <path d="M14,3V5H17.59L7.76,14.83L9.17,16.24L19,6.41V10H21V3M19,19H5V5H12V3H5C3.89,3 3,3.9 3,5V19A2,2 0 0,0 5,21H19A2,2 0 0,0 21,19V12H19V19Z"/>
+              </svg>
+            </a>
+            <a 
+              href={GITHUB_REPO_URL} 
+              target="_blank" 
+              rel="noopener noreferrer"
+              style={{ 
+                color: 'white', 
+                textDecoration: 'none',
+                display: 'flex',
+                alignItems: 'center',
+                opacity: 0.8,
+                transition: 'opacity 0.2s'
+              }}
+              onMouseEnter={(e) => e.currentTarget.style.opacity = '1'}
+              onMouseLeave={(e) => e.currentTarget.style.opacity = '0.8'}
+              title="View on GitHub"
+            >
+              <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor">
+                <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.30 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/>
+              </svg>
+            </a>
+          </div>
         </header>
 
         <Routes>

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -1,3 +1,4 @@
 // Configuration constants for the NWB Assistant application
 export const GITHUB_REPO_URL = 'https://github.com/magland/nwb-assistant';
 export const GITHUB_ISSUES_URL = `${GITHUB_REPO_URL}/issues`;
+export const DEPLOYMENT_URL = 'https://magland.github.io/nwb-assistant/chat';


### PR DESCRIPTION
Problem: When a user is interacting with nwb assistant, if they want to navigate to different pages in the docs they lose the assistant iframe.

Solution: Provide a pop-out button that opens the chat in a separate window, so a user can place it side-by-side with the docs and navigate freely while conversing with the bot